### PR TITLE
PADV-2388: add event to capture the grade of an LTI 1.1 content

### DIFF
--- a/openedx_events/content_authoring/data.py
+++ b/openedx_events/content_authoring/data.py
@@ -194,3 +194,19 @@ class ContentObjectData:
     """
 
     object_id = attr.ib(type=str)
+
+
+@attr.s(frozen=True)
+class Lti1p1ContentGraded:
+    """
+    Data about LTI 1.1 content object.
+
+    Arguments:
+        user_id (int): database identifier of the learner's LMS user.
+        xblock_id (UsageKey): Location of the Xblock reponsible to launch the LTI content.
+        anonymous_user_id (str): Anonymous id of the Learner's LMS user.
+    """
+
+    user_id = attr.ib(type=int)
+    xblock_id = attr.ib(type=UsageKey)
+    anonymous_user_id = attr.ib(type=str)

--- a/openedx_events/content_authoring/signals.py
+++ b/openedx_events/content_authoring/signals.py
@@ -15,6 +15,7 @@ from openedx_events.content_authoring.data import (
     CourseData,
     DuplicatedXBlockData,
     LibraryBlockData,
+    Lti1p1ContentGraded,
     XBlockData,
 )
 from openedx_events.tooling import OpenEdxPublicSignal
@@ -209,4 +210,17 @@ CONTENT_OBJECT_TAGS_CHANGED = OpenEdxPublicSignal(
     data={
         "content_object": ContentObjectData
     }
+)
+
+# .. event_type: org.openedx.content_authoring.xblock.lti1p1.content.graded.v1
+# .. event_name: XBLOCK_LTI1P1_GRADED
+# .. event_key_field: xblock.scope_ids.usage_id
+# .. event_description: emitted when an LTI 1.1 Content is graded via Xblock's OutcomeService
+# .. event_data: Lti1p1ContentGraded
+# .. event_trigger_repository: Pearson-Advance/xblock-lti-consumer
+XBLOCK_LTI1P1_GRADED = OpenEdxPublicSignal(
+    event_type="org.openedx.content_authoring.xblock.lti1p1.content.graded.v1",
+    data={
+        "graded_content": Lti1p1ContentGraded,
+    },
 )

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+xblock+lti1p1+content+graded+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+xblock+lti1p1+content+graded+v1_schema.avsc
@@ -1,0 +1,29 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "graded_content",
+      "type": {
+        "name": "Lti1p1ContentGraded",
+        "type": "record",
+        "fields": [
+          {
+            "name": "user_id",
+            "type": "long"
+          },
+          {
+            "name": "xblock_id",
+            "type": "string"
+          },
+          {
+            "name": "anonymous_user_id",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.content_authoring.xblock.lti1p1.content.graded.v1"
+}


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-2388

## Description

This PR creates an event that catches the Outcome service request of the Xblock LTI 1.1 when the content is being graded by the LTI Tool Provider. 

## Changes Made

- [x] Adds XBLOCK_LTI1P1_GRADED event into the `content_authoring` subdomain
- [x] Creates the [avro schema](https://docs.openedx.org/projects/openedx-events/en/latest/how-tos/add-event-bus-support-to-an-event.html#step-4-generate-the-avro-schema) in order to provide event bus support to the event 

The avro schema has been created via 
```
python manage.py lms generate_avro_schemas org.openedx.content_authoring.xblock.lti1p1.content.graded.v1
```
## Note

CIs aren't being executed nonetheless here's the output of `make quality` and `make test` in local using a python 3.8 venv

<img width="1206" height="450" alt="image" src="https://github.com/user-attachments/assets/9faafa9c-a2b9-43e3-8ecf-690cc8d596bf" />

<img width="1206" height="543" alt="image" src="https://github.com/user-attachments/assets/f752416b-8a42-4671-9ec4-a231797b1c85" />
