### PR TITLE
fix: add pep440 support for eventmetada sourcelib field

### DIFF
--- a/openedx_events/data.py
+++ b/openedx_events/data.py
@@ -102,7 +102,7 @@ class EventsMetadata:
     sourcelib = attr.ib(
         type=tuple, default=None,
         converter=attr.converters.default_if_none(
-            attr.Factory(lambda: tuple(map(int, openedx_events.__version__.split("."))))
+            attr.Factory(lambda: tuple(openedx_events.__version__.split(".")))
         ),
         validator=attr.validators.instance_of(tuple),
     )


### PR DESCRIPTION
## Description

This PR fixes and issue caused by the field sourcelib of the EventsMetadata, this field does not support [PEP440](https://peps.python.org/pep-0440/#public-version-identifiers) since it tries to parse into integer every section of the openedx-events package versions. This causes that any post, pre or development releases raises an error due that mapping. 

Here's a screenshot of the issue found via xblock-lti-consumer. 

<img width="1206" height="429" alt="image" src="https://github.com/user-attachments/assets/b2a57320-6d40-49ae-986c-c178ac6dc005" />

