### PR TITLE
PADV-2729 - cherry picks add event to captrue the grade of an LTI 1.1 content and add pep440 support for eventmetada sourcelib field

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -218,6 +218,22 @@ Added
 * Added a ``UuidAvroSerializer`` to serialize uuid fields.
 * Added ``isort`` make target.
 
+[9.10.0.post2] - 2025-07-11
+---------------------
+
+changed
+~~~~~~~
+
+* PEP440 support for eventmetada sourcelib field
+
+[9.10.0.post1] - 2025-07-10
+---------------------
+
+Added
+~~~~~~~
+
+* Added new ``XBLOCK_LTI1P1_GRADED`` events in content_authoring.
+
 [9.10.0] - 2024-05-08
 ---------------------
 

--- a/openedx_events/content_authoring/data.py
+++ b/openedx_events/content_authoring/data.py
@@ -248,3 +248,19 @@ class LibraryContainerData:
 
     container_key = attr.ib(type=LibraryContainerLocator)
     background = attr.ib(type=bool, default=False)
+
+
+@attr.s(frozen=True)
+class Lti1p1ContentGraded:
+    """
+    Data about LTI 1.1 content object.
+
+    Arguments:
+        user_id (int): database identifier of the learner's LMS user.
+        xblock_id (UsageKey): Location of the Xblock reponsible to launch the LTI content.
+        anonymous_user_id (str): Anonymous id of the Learner's LMS user.
+    """
+
+    user_id = attr.ib(type=int)
+    xblock_id = attr.ib(type=UsageKey)
+    anonymous_user_id = attr.ib(type=str)

--- a/openedx_events/content_authoring/signals.py
+++ b/openedx_events/content_authoring/signals.py
@@ -18,6 +18,7 @@ from openedx_events.content_authoring.data import (
     LibraryBlockData,
     LibraryCollectionData,
     LibraryContainerData,
+    Lti1p1ContentGraded,
     XBlockData,
 )
 from openedx_events.tooling import OpenEdxPublicSignal
@@ -369,4 +370,17 @@ COURSE_RERUN_COMPLETED = OpenEdxPublicSignal(
     data={
         "course": CourseData,
     }
+)
+
+# .. event_type: org.openedx.content_authoring.xblock.lti1p1.content.graded.v1
+# .. event_name: XBLOCK_LTI1P1_GRADED
+# .. event_key_field: xblock.scope_ids.usage_id
+# .. event_description: emitted when an LTI 1.1 Content is graded via Xblock's OutcomeService
+# .. event_data: Lti1p1ContentGraded
+# .. event_trigger_repository: Pearson-Advance/xblock-lti-consumer
+XBLOCK_LTI1P1_GRADED = OpenEdxPublicSignal(
+    event_type="org.openedx.content_authoring.xblock.lti1p1.content.graded.v1",
+    data={
+        "graded_content": Lti1p1ContentGraded,
+    },
 )

--- a/openedx_events/data.py
+++ b/openedx_events/data.py
@@ -101,7 +101,7 @@ class EventsMetadata:
     sourcelib = attr.ib(
         type=tuple, default=None,
         converter=attr.converters.default_if_none(
-            attr.Factory(lambda: tuple(map(int, openedx_events.__version__.split("."))))
+            attr.Factory(lambda: tuple(openedx_events.__version__.split(".")))
         ),
         validator=attr.validators.instance_of(tuple),
     )

--- a/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+xblock+lti1p1+content+graded+v1_schema.avsc
+++ b/openedx_events/event_bus/avro/tests/schemas/org+openedx+content_authoring+xblock+lti1p1+content+graded+v1_schema.avsc
@@ -1,0 +1,29 @@
+{
+  "name": "CloudEvent",
+  "type": "record",
+  "doc": "Avro Event Format for CloudEvents created with openedx_events/schema",
+  "fields": [
+    {
+      "name": "graded_content",
+      "type": {
+        "name": "Lti1p1ContentGraded",
+        "type": "record",
+        "fields": [
+          {
+            "name": "user_id",
+            "type": "long"
+          },
+          {
+            "name": "xblock_id",
+            "type": "string"
+          },
+          {
+            "name": "anonymous_user_id",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "namespace": "org.openedx.content_authoring.xblock.lti1p1.content.graded.v1"
+}


### PR DESCRIPTION
## Tickets

- [https://agile-jira.pearson.com/browse/PADV-2729](https://pearson.atlassian.net/browse/PADV-2729)

## Description

This PR adds two cherry-picks commits from pearson-release/olive.main:

- https://github.com/Pearson-Advance/openedx-events/pull/1 creates an event that catches the Outcome service request of the Xblock LTI 1.1 when the content is being graded by the LTI Tool Provider. 
- https://github.com/Pearson-Advance/openedx-events/pull/2 fixes and issue caused by the field sourcelib of the EventsMetadata, this field does not support [PEP440](https://peps.python.org/pep-0440/#public-version-identifiers) since it tries to parse into integer every section of the openedx-events package versions. This causes that any post, pre or development releases raises an error due that mapping.